### PR TITLE
Add OWNERS file to enable Prow approve workflow

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- smrtrfszm
+- TwoDCube


### PR DESCRIPTION
Copies the OWNERS file used by website_frontend and website_backend2 (approvers: smrtrfszm, TwoDCube) so the Prow approve plugin can grant the `approved` label on this repo.